### PR TITLE
move createHiveAlert initialization before env input

### DIFF
--- a/lambda/lambda_alarm_hive.py
+++ b/lambda/lambda_alarm_hive.py
@@ -69,7 +69,6 @@ def create_issue_for_account(accountId, excludeAccountFilter):
 
 def lambda_handler(event, context):
     debug = False
-    createHiveAlert = True
     createHiveAlert = json.loads(os.environ['createHiveAlert'].lower())
     excludeAccountFilter = os.environ['excludeAccountFilter']
     debug = os.environ['debug']


### PR DESCRIPTION
Fix issue that causes the lambda to always create Hive alerts. The initialisation of createHiveAlert is put after the environment variable is used to populate the variable. This causes the variable to alway be true even if the environment var is set to false. 

This fix moves the initialisation to the top of the function. 